### PR TITLE
DFD-Layout- und Händler-Copy-Paste-Fehler behoben

### DIFF
--- a/_Aufgaben/A03_DFDs.tex
+++ b/_Aufgaben/A03_DFDs.tex
@@ -10,7 +10,7 @@ Diagramme wie im ersten Hefteintrag, die Eingabe, Verarbeitung und Ausgabe darst
     \node[dfddata, text width=2.1cm, right=0.3cm of gq2] (tq2) {Umsatz Tennis Q2};
     \node[dfddata, text width=2.1cm, right=0.3cm of tq2] (sq2) {Umsatz Safari Q2};
 
-    \node[oval, text width=2.2cm, below=1cm of tq2] (summe) {SUMME (nicht + ! )};
+    \node[oval, text width=2.2cm, below=0.8cm of tq2] (summe) {SUMME (nicht + ! )};
     
     \node[dfddata, below=1cm of summe] (final) {Gesamtumsatz Q2};
     
@@ -24,7 +24,7 @@ Diagramme wie im ersten Hefteintrag, die Eingabe, Verarbeitung und Ausgabe darst
     \node[dfddata, text width=2.1cm, right=1cm of sq2] (golf) {Umsatz Golf Q2};
     \node[dfddata, text width=2.4cm, right=0.3cm of golf] (fakt) {Wachstums-faktor};
 
-    \node[oval, text width=2.2cm, below=1cm of $(golf)!0.5!(fakt)$] (stern) {PRODUKT oder *};
+    \node[oval, text width=2.2cm, below=0.8cm of $(golf)!0.5!(fakt)$] (stern) {PRODUKT oder *};
     
     \node[dfddata, below=1cm of stern] (gq3) {Umsatz Golf Q3};
     

--- a/_Aufgaben/A05_Getraenke.tex
+++ b/_Aufgaben/A05_Getraenke.tex
@@ -91,7 +91,7 @@
     \LoesungTikz{
             \node[dfddata, text width=1.8cm, minimum width=1pt] (e1) {Anzahl Gäste};
             \node[dfddata, text width=3cm, right=0.3cm of e1, minimum width=1pt] (e2) {Konsum Spezi pro Gast};
-            \node[dfddata, text width=3cm, right=0.3cm of e2] (eN) {Flaschenpreis Spezi};
+            \node[dfddata, text width=2.5cm, right=0.3cm of e2] (eN) {Flaschenpreis Spezi};
 
             \node[oval, text width=4.5cm, below=1.5cm of e2] (fkt) {Einkaufskosten Spezi berechnen};
             
@@ -106,7 +106,7 @@
     \LoesungTikz{
             \node[dfddata, text width=1.8cm, minimum width=1pt] (e1) {Anzahl Gäste};
             \node[dfddata, text width=3cm, right=0.3cm of e1, minimum width=1pt] (e2) {Konsum Wasser pro Gast};
-            \node[dfddata, text width=3cm, right=0.3cm of e2] (eN) {Flaschenpreis Wasser};
+            \node[dfddata, text width=2.5cm, right=0.3cm of e2] (eN) {Flaschenpreis Wasser};
 
             \node[oval, text width=4.5cm, below=1.5cm of e2] (fkt) {Einkaufskosten Wasser berechnen};
             
@@ -123,9 +123,9 @@
 
 \UnterAufgabe{Getränkekalkuation A2 (2)}{
     \LoesungTikz{
-            \node[dfddata, text width=1.8cm, minimum width=1pt] (e1) {Anzahl Gäste};
-            \node[dfddata, text width=3cm, right=0.3cm of e1, minimum width=1pt] (e2) {Konsum Bier pro Gast};
-            \node[dfddata, text width=3cm, right=0.3cm of e2] (eN) {Flaschenpreis Bier};
+            \node[dfddata, text width=1.7cm, minimum width=1pt] (e1) {Anzahl Gäste};
+            \node[dfddata, text width=2.5cm, right=0.2cm of e1, minimum width=1pt] (e2) {Konsum Bier pro Gast};
+            \node[dfddata, text width=2.5cm, right=0.2cm of e2] (eN) {Flaschenpreis Bier};
 
             \node[oval, text width=4.5cm, below=1.5cm of e2] (fkt) {Einkaufskosten Bier berechnen};
             
@@ -138,9 +138,9 @@
             \draw[arrow] (fkt) -- (final);
     }
     \LoesungTikz{
-            \node[dfddata, text width=2.5cm, minimum width=1pt] (e1) {Einkaufskosten Spezi};
-            \node[dfddata, text width=3cm, right=0.3cm of e1, minimum width=1pt] (e2) {Einkaufskosten Wasser};
-            \node[dfddata, text width=2.5cm, right=0.3cm of e2] (eN) {Einkaufskosten Bier};
+            \node[dfddata, text width=2.4cm, minimum width=1pt] (e1) {Einkaufskosten Spezi};
+            \node[dfddata, text width=2.5cm, right=0.3cm of e1, minimum width=1pt] (e2) {Einkaufskosten Wasser};
+            \node[dfddata, text width=2.2cm, right=0.3cm of e2] (eN) {Einkaufskosten Bier};
 
             \node[oval, text width=4.5cm, below=1.5cm of e2] (fkt) {Einkaufskosten gesamt berechnen};
             

--- a/_Aufgaben/A05_Getraenke.tex
+++ b/_Aufgaben/A05_Getraenke.tex
@@ -160,11 +160,11 @@
     \fi
     
     \LoesungTikz{
-            \node[dfddata, text width=1.5cm, minimum width=1pt] (e1) {Anzahl Gäste};
-            \node[dfddata, text width=1.5cm, right=0.3cm of e1, minimum width=1pt] (e2) {Konsum Spezi pro Gast};
-            \node[dfddata, text width=1.5cm, right=0.3cm of e2] (eN) {Verkaufspreis Spezi};
+            \node[dfddata, text width=1.2cm, minimum width=1pt] (e1) {Anzahl Gäste};
+            \node[dfddata, text width=1.5cm, right=0.2cm of e1, minimum width=1pt] (e2) {Konsum Spezi pro Gast};
+            \node[dfddata, text width=1.5cm, right=0.2cm of e2] (eN) {Verkaufspreis Spezi};
 
-            \node[oval, text width=3.5cm, below=1cm of e2] (fkt) {Einnahmen Spezi berechnen};
+            \node[oval, text width=3.2cm, below=1cm of e2] (fkt) {Einnahmen Spezi berechnen};
             
             \node[dfddata, below=0.5cm of fkt] (final) {Einnahmen Spezi};
             
@@ -175,11 +175,11 @@
             \draw[arrow] (fkt) -- (final);
     }
     \LoesungTikz{
-            \node[dfddata, text width=1.5cm, minimum width=1pt] (e1) {Anzahl Gäste};
+            \node[dfddata, text width=1.2cm, minimum width=1pt] (e1) {Anzahl Gäste};
             \node[dfddata, text width=1.5cm, right=0.3cm of e1, minimum width=1pt] (e2) {Konsum Wasser pro Gast};
             \node[dfddata, text width=1.5cm, right=0.3cm of e2] (eN) {Verkaufspreis Wasser};
 
-            \node[oval, text width=3.5cm, below=1cm of e2] (fkt) {Einnahmen Wasser berechnen};
+            \node[oval, text width=3.2cm, below=1cm of e2] (fkt) {Einnahmen Wasser berechnen};
             
             \node[dfddata, below=0.5cm of fkt] (final) {Einnahmen Wasser};
             
@@ -190,11 +190,11 @@
             \draw[arrow] (fkt) -- (final);
     }
     \LoesungTikz{
-            \node[dfddata, text width=1.5cm, minimum width=1pt] (e1) {Anzahl Gäste};
+            \node[dfddata, text width=1.2cm, minimum width=1pt] (e1) {Anzahl Gäste};
             \node[dfddata, text width=1.5cm, right=0.3cm of e1, minimum width=1pt] (e2) {Konsum Bier pro Gast};
             \node[dfddata, text width=1.5cm, right=0.3cm of e2] (eN) {Verkaufspreis Bier};
 
-            \node[oval, text width=3.5cm, below=1cm of e2] (fkt) {Einnahmen Bier berechnen};
+            \node[oval, text width=3.2cm, below=1cm of e2] (fkt) {Einnahmen Bier berechnen};
             
             \node[dfddata, below=0.5cm of fkt] (final) {Einnahmen Bier};
             

--- a/_Aufgaben/A05_Getraenke.tex
+++ b/_Aufgaben/A05_Getraenke.tex
@@ -233,11 +233,11 @@
            % \node[dfddata, text width=0.5cm, minimum height=8pt, right=0.2cm of e1] (e2) {...};
             %\node[text width=0.5cm, minimum width=1pt, minimum height=8pt, right=0.2cm of e2] (edots) {...};
             %\node[dfddata, text width=0.5cm, minimum height=8pt, right=0.2cm of edots] (e3) {...};
-            \node[dfddata, text width=2.3cm, right=0.2cm of e1] (eN) {Einkaufskosten bei Händler 1};
+            \node[dfddata, text width=2.3cm, right=0.2cm of e1] (eN) {Einkaufskosten bei Händler 2};
 
-            \node[oval, text width=3cm, below=1.5cm of $(e1)!0.5!(eN)$] (fkt) {Gewinn bei Händler 1 berechnen};
+            \node[oval, text width=3cm, below=1.5cm of $(e1)!0.5!(eN)$] (fkt) {Gewinn bei Händler 2 berechnen};
             
-            \node[dfddata, below=0.5cm of fkt] (final) {Gewinn bei Händler 1};
+            \node[dfddata, below=0.5cm of fkt] (final) {Gewinn bei Händler 2};
             
             \draw[arrow] (e1) -- (fkt);
             %\draw[arrow] (e2) -- (fkt);

--- a/_Aufgaben/A05_Getraenke.tex
+++ b/_Aufgaben/A05_Getraenke.tex
@@ -30,13 +30,13 @@
     \fi
     
     \LoesungTikz{
-            \node[dfddata, text width=2cm, minimum width=1pt] (e1) {Preis Kasten Spezi};
+            \node[dfddata, text width=1.8cm, minimum width=1pt] (e1) {Preis Kasten Spezi};
            % \node[dfddata, text width=0.5cm, minimum height=8pt, right=0.2cm of e1] (e2) {...};
             %\node[text width=0.5cm, minimum width=1pt, minimum height=8pt, right=0.2cm of e2] (edots) {...};
             %\node[dfddata, text width=0.5cm, minimum height=8pt, right=0.2cm of edots] (e3) {...};
-            \node[dfddata, text width=3cm, right=0.2cm of e1] (eN) {Anzahl Flaschen pro Kasten Spezi};
+            \node[dfddata, text width=2.7cm, right=0.2cm of e1] (eN) {Anzahl Flaschen pro Kasten Spezi};
 
-            \node[oval, text width=3.5cm, below=1.5cm of $(e1)!0.5!(eN)$] (fkt) {Flaschenpreis Spezi berechnen};
+            \node[oval, text width=3.2cm, below=1.5cm of $(e1)!0.5!(eN)$] (fkt) {Flaschenpreis Spezi berechnen};
             
             \node[dfddata, below=0.5cm of fkt] (final) {Flaschenpreis Spezi};
             
@@ -47,13 +47,13 @@
             \draw[arrow] (fkt) -- (final);
     }
     \LoesungTikz{
-            \node[dfddata, text width=2cm, minimum width=1pt] (e1) {Preis Kasten Wasser};
+            \node[dfddata, text width=1.8cm, minimum width=1pt] (e1) {Preis Kasten Wasser};
            % \node[dfddata, text width=0.5cm, minimum height=8pt, right=0.2cm of e1] (e2) {...};
             %\node[text width=0.5cm, minimum width=1pt, minimum height=8pt, right=0.2cm of e2] (edots) {...};
             %\node[dfddata, text width=0.5cm, minimum height=8pt, right=0.2cm of edots] (e3) {...};
-            \node[dfddata, text width=3cm, right=0.2cm of e1] (eN) {Anzahl Flaschen pro Kasten Wasser};
+            \node[dfddata, text width=2.7cm, right=0.2cm of e1] (eN) {Anzahl Flaschen pro Kasten Wasser};
 
-            \node[oval, text width=3.5cm, below=1.5cm of $(e1)!0.5!(eN)$] (fkt) {Flaschenpreis Wasser berechnen};
+            \node[oval, text width=3.2cm, below=1.5cm of $(e1)!0.5!(eN)$] (fkt) {Flaschenpreis Wasser berechnen};
             
             \node[dfddata, below=0.5cm of fkt] (final) {Flaschenpreis Wasser};
             
@@ -64,13 +64,13 @@
             \draw[arrow] (fkt) -- (final);
     }
     \LoesungTikz{
-            \node[dfddata, text width=2cm, minimum width=1pt] (e1) {Preis Kasten Bier};
+            \node[dfddata, text width=1.8cm, minimum width=1pt] (e1) {Preis Kasten Bier};
            % \node[dfddata, text width=0.5cm, minimum height=8pt, right=0.2cm of e1] (e2) {...};
             %\node[text width=0.5cm, minimum width=1pt, minimum height=8pt, right=0.2cm of e2] (edots) {...};
             %\node[dfddata, text width=0.5cm, minimum height=8pt, right=0.2cm of edots] (e3) {...};
-            \node[dfddata, text width=3cm, right=0.2cm of e1] (eN) {Anzahl Flaschen pro Kasten Bier};
+            \node[dfddata, text width=2.7cm, right=0.2cm of e1] (eN) {Anzahl Flaschen pro Kasten Bier};
 
-            \node[oval, text width=3.5cm, below=1.5cm of $(e1)!0.5!(eN)$] (fkt) {Flaschenpreis Bier berechnen};
+            \node[oval, text width=3.2cm, below=1.5cm of $(e1)!0.5!(eN)$] (fkt) {Flaschenpreis Bier berechnen};
             
             \node[dfddata, below=0.5cm of fkt] (final) {Flaschenpreis Bier};
             


### PR DESCRIPTION
This pull request refines the visual presentation of Data Flow Diagrams (DFDs) in assignments A03 and A05, and corrects a specific naming error in A05.

*   **A03 DFD Layout Improvements:**
    *   Adjusts the vertical spacing between DFD nodes, reducing it from `1cm` to `0.8cm`. This creates a more compact and aesthetically pleasing layout for process nodes like `SUMME` and `PRODUKT`.

*   **A05 Layout Optimizations:**
    *   Optimizes `text width` properties for various data and process nodes across the bottle price, purchase cost, and revenue calculation DFDs. These adjustments ensure better text fitting within diagram elements, improving overall readability and visual balance.

*   **A05 Händler Name Fix:**
    *   Corrects an incorrect "Händler" (dealer/supplier) name in the profit calculation diagram. References are updated from "Händler 1" to "Händler 2" for accuracy.
    * 
closes #1 