### PR TITLE
Verteiler erklärung abgeändert, dass auch mehrere möglich sind.

### DIFF
--- a/_Hefteintraege/H07_Verkettung.tex
+++ b/_Hefteintraege/H07_Verkettung.tex
@@ -1,5 +1,5 @@
 \Hefteintrag{2}{Verkettung von Funktionen}{
-    Wenn der \LoesungLuecke{Ausgabewert}{6cm} einer Funktion als \LoesungLuecke{Eingabewert}{6cm} einer anderen Funktion verwendet wird, spricht man von \LoesungLuecke{Verkettung}{6cm} von Funktionen. In Datenflussdiagrammen können \LoesungLuecke{Datenblöcke}{7cm} zwischen \LoesungLuecke{2 Funktionen}{10cm} weggelassen werden. Hierbei ist es dann besonders wichtig, aussagekräftige Funktionsnamen zu wählen. Mit einem \LoesungLuecke{Verteiler}{6cm} kann ein Datenfluss in zwei aufgeteilt werden. 
+    Wenn der \LoesungLuecke{Ausgabewert}{6cm} einer Funktion als \LoesungLuecke{Eingabewert}{6cm} einer anderen Funktion verwendet wird, spricht man von \LoesungLuecke{Verkettung}{6cm} von Funktionen. In Datenflussdiagrammen können \LoesungLuecke{Datenblöcke}{7cm} zwischen \LoesungLuecke{2 Funktionen}{10cm} weggelassen werden. Hierbei ist es dann besonders wichtig, aussagekräftige Funktionsnamen zu wählen. Mit einem \LoesungLuecke{Verteiler}{6cm} kann ein Datenfluss in mehrere aufgeteilt werden. 
 
     \vspace{0.1cm}
     \begin{minipage}[t]{0.5\textwidth}


### PR DESCRIPTION
Ein Verteiler kann in beliebig viele aufteilen, nicht nur zwei.